### PR TITLE
Support OpenFOAM v2112

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,112 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  docker:
+    name: OpenFOAM v${{ matrix.foam_version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        foam_version:
+          - '2112'
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build '-run' image
+        uses: docker/build-push-action@v2
+        with:
+          build-args: FOAM_VERSION=${{ matrix.foam_version }}
+          file: openfoam-run_leap.Dockerfile
+          context: .
+          platforms: linux/arm64
+          load: true
+          tags: gerlero/openfoam${{ matrix.foam_version }}-run
+      -
+        name: Test '-run' image
+        run: |
+          ./openfoam-docker-arm -${{ matrix.foam_version }} -run -- foamInstallationTest
+          ./openfoam-docker-arm -${{ matrix.foam_version }} -dev -- icoFoam -help
+        shell: 'script -q -e -c "bash -e {0}"'
+      -
+        name: Push '-run' image
+        uses: docker/build-push-action@v2
+        with:
+          build-args: FOAM_VERSION=${{ matrix.foam_version }}
+          file: openfoam-run_leap.Dockerfile
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: gerlero/openfoam${{ matrix.foam_version }}-run
+      -
+        name: Build '-dev' image
+        uses: docker/build-push-action@v2
+        with:
+          build-args: FOAM_VERSION=${{ matrix.foam_version }}
+          file: openfoam-dev_leap.Dockerfile
+          context: .
+          platforms: linux/arm64
+          load: true
+          tags: gerlero/openfoam${{ matrix.foam_version }}-dev
+      -
+        name: Test '-dev' image
+        run: |
+          ./openfoam-docker-arm -${{ matrix.foam_version }} -dev -- foamInstallationTest
+          ./openfoam-docker-arm -${{ matrix.foam_version }} -dev -- icoFoam -help
+        shell: 'script -q -e -c "bash -e {0}"'
+      -
+        name: Push '-dev' image
+        uses: docker/build-push-action@v2
+        with:
+          build-args: FOAM_VERSION=${{ matrix.foam_version }}
+          file: openfoam-dev_leap.Dockerfile
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: gerlero/openfoam${{ matrix.foam_version }}-dev
+      -
+        name: Build '-default' image
+        uses: docker/build-push-action@v2
+        with:
+          build-args: FOAM_VERSION=${{ matrix.foam_version }}
+          file: openfoam-default_leap.Dockerfile
+          context: .
+          platforms: linux/arm64
+          load: true
+          tags: gerlero/openfoam${{ matrix.foam_version }}-default
+      -
+        name: Test '-default' image
+        run: |
+          ./openfoam-docker-arm -${{ matrix.foam_version }} -default -- foamInstallationTest
+          ./openfoam-docker-arm -${{ matrix.foam_version }} -default -- icoFoam -help
+          ./openfoam-docker-arm -${{ matrix.foam_version }} -default -- foamTestTutorial -full incompressible/simpleFoam/pitzDaily
+          ./openfoam-docker-arm -${{ matrix.foam_version }} -default -- foamTestTutorial -full -parallel basic/laplacianFoam/flange
+        shell: 'script -q -e -c "bash -e {0}"'
+      -
+        name: Push '-default' image
+        uses: docker/build-push-action@v2
+        with:
+          build-args: FOAM_VERSION=${{ matrix.foam_version }}
+          file: openfoam-default_leap.Dockerfile
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: gerlero/openfoam${{ matrix.foam_version }}-default

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenFOAM for ARM via Docker
 
+[![CI](https://github.com/gerlero/openfoam-docker-arm/actions/workflows/ci.yml/badge.svg)](https://github.com/gerlero/openfoam-docker-arm/actions/workflows/ci.yml)
+
 Precompiled OpenFOAM environment for ARM-based processors via Docker.
 
 **For use on Macs with Apple silicon and other ARM-based computers.**
@@ -29,21 +31,17 @@ Then, launch an ARM-based OpenFOAM environment at any time using the script. For
 ./openfoam-docker-arm -default
 ```
 
-For more details on how to use the script and OpenFOAM with Docker in general, you may want to check out the [OpenFOAM Docker page](https://develop.openfoam.com/Development/openfoam/-/wikis/precompiled/docker).
+The `-default` option requests a full environment (including the tutorial suite and dependencies needed for OpenFOAM development). To ask for a specific OpenFOAM version, pass the version number as an option (as of now, `-2112` or `-2106` will work). For help on how to use the script and OpenFOAM with Docker in general, use the `-help` option and/or check out the [OpenFOAM Docker page](https://develop.openfoam.com/Development/openfoam/-/wikis/precompiled/docker).
 
-## Docker image
+## Details
 
-The Docker image used by the script is available as [`gerlero/openfoam2016-default`](https://hub.docker.com/r/gerlero/openfoam2106-default). It is intended to directly replace the [official Docker images](https://hub.docker.com/r/opencfd/) by OpenCFD. Currently, `-dev` and `-run` "slimmer" images are provided as aliases of the `-default` image.
+### OpenFOAM v2112
 
-### Building the image
+ARM-based OpenFOAM v2112 environments are packaged in Docker images based on OpenSUSE Leap, using the official ARM binaries as recommended in the [OpenFOAM Docker FAQ](https://develop.openfoam.com/Development/openfoam/-/wikis/precompiled/docker#frequently-asked-questions). Note that the base distribution differs from the [official Docker images](`https://hub.docker.com/u/opencfd`), which use Ubuntu. The ARM-based Docker images are built here using GitHub Actions and provided as [`gerlero/openfoam2112-run`](https://hub.docker.com/r/gerlero/openfoam2112-run), [`gerlero/openfoam2112-dev`](https://hub.docker.com/r/gerlero/openfoam2112-dev) and [`gerlero/openfoam2112-default`](https://hub.docker.com/r/gerlero/openfoam2112-default).
 
-If you want to manually build the image, clone this repo and run:
+### OpenFOAM v2106
 
-```sh
-docker build --build-arg FOAM_VERSION=2106 --platform linux/arm64 -t gerlero/openfoam2106-default -f openfoam-default.Dockerfile .
-```
-
-Note that the build can take a long time, as it will compile OpenFOAM entirely from its source code.
+The ARM-based OpenFOAM v2106 Docker image is available as [`gerlero/openfoam2016-default`](https://hub.docker.com/r/gerlero/openfoam2106-default). The current version of this image offers OpenFOAM compiled from source on Ubuntu, with the `-dev` and `-run` "slimmer" images provided as simple aliases of the `-default` image.
 
 ## License
 

--- a/openfoam-default_leap.Dockerfile
+++ b/openfoam-default_leap.Dockerfile
@@ -1,0 +1,24 @@
+# ---------------------------------*-sh-*------------------------------------
+# Copyright (C) 2021 OpenCFD Ltd.
+# Copyright (C) 2022 Gabriel S. Gerlero
+# SPDX-License-Identifier: (GPL-3.0+)
+#
+# Add default (tutorials etc) layer onto the openfoam '-dev' (openSUSE) image.
+#
+# Example
+#     docker build -f openfoam-default_leap.Dockerfile .
+#     docker build --build-arg FOAM_VERSION=2112
+#         -t gerlero/openfoam2112-default ...
+#
+# ---------------------------------------------------------------------------
+ARG FOAM_VERSION=2112
+
+FROM gerlero/openfoam${FOAM_VERSION}-dev
+ARG FOAM_VERSION
+ARG PACKAGE=openfoam${FOAM_VERSION}-default
+
+RUN zypper install -y ${PACKAGE} \
+ && zypper -n clean
+
+
+# ---------------------------------------------------------------------------

--- a/openfoam-dev_leap.Dockerfile
+++ b/openfoam-dev_leap.Dockerfile
@@ -1,0 +1,24 @@
+# ---------------------------------*-sh-*------------------------------------
+# Copyright (C) 2021 OpenCFD Ltd.
+# Copyright (C) 2022 Gabriel S. Gerlero
+# SPDX-License-Identifier: (GPL-3.0+)
+#
+# Add development layer onto the openfoam '-run' (openSUSE) image.
+#
+# Example
+#     docker build -f openfoam-dev_leap.Dockerfile .
+#     docker build --build-arg FOAM_VERSION=2112
+#         -t gerlero/openfoam2112-dev ...
+#
+# ---------------------------------------------------------------------------
+ARG FOAM_VERSION=2112
+
+FROM gerlero/openfoam${FOAM_VERSION}-run
+ARG FOAM_VERSION
+ARG PACKAGE=openfoam${FOAM_VERSION}-devel
+
+RUN zypper install -y ${PACKAGE} \
+ && zypper -n clean
+
+
+# ---------------------------------------------------------------------------

--- a/openfoam-docker-arm
+++ b/openfoam-docker-arm
@@ -1,8 +1,8 @@
 #!/bin/sh
-openfoamVersion="2106"
 imageBasename="gerlero/openfoam"
+openfoamVersion="2112"
 imageFlavour="-run"
-scriptVersion="2021-06-23"
+scriptVersion="2021-12-21"
 
 #------------------------------------------------------------------------------
 # =========                 |
@@ -12,10 +12,9 @@ scriptVersion="2021-06-23"
 #    \\/     M anipulation  |
 #------------------------------------------------------------------------------
 #    Copyright (C) 2016-2021 OpenCFD Ltd.
-#    Copyright (C) 2021 Gabriel S. Gerlero
+#    Copyright (C) 2021-2022 Gabriel S. Gerlero
 #------------------------------------------------------------------------------
-# License
-#     An OpenFOAM-associated file, distributed under GPL-3.0-or-later.
+# SPDX-License-Identifier: (GPL-3.0+)
 #
 # Script
 #     openfoam-docker-arm
@@ -26,7 +25,7 @@ scriptVersion="2021-06-23"
 #     Copy/link to automatically specify OpenFOAM version and image 'flavour'
 #     For example,
 #
-#        ln -s openfoam-docker-arm openfoam2106-run
+#        ln -s openfoam-docker-arm openfoam2112-run
 #
 #------------------------------------------------------------------------------
 printHelp()
@@ -42,7 +41,7 @@ options:
   -c                Shell commands read from the first non-option argument
   -data=DIR         Specify mount dir for container '/data'
   -dir=DIR          Specify mount dir for container '~/' (default: pwd)
-  -<digits>         Specify OpenFOAM version (eg, -2106)
+  -<digits>         Specify OpenFOAM version (eg, -2112)
   -base | -dev | -run | -tut | -default
                     Image flavour (default: -run).
                     Not all image flavours are necessarily available.
@@ -186,7 +185,7 @@ do
         break   # Stop option parsing
         ;;
 
-    # OpenFOAM versions (eg, -2012, -2106, etc)
+    # OpenFOAM versions (eg, -2112, -2106, -2012, etc)
     (-[1-9]*)   openfoamVersion="${1#*-}" ;;
     (-v[1-9]*)  openfoamVersion="${1#*-v}" ;;
 

--- a/openfoam-files.rc/assets/profile.sh.in
+++ b/openfoam-files.rc/assets/profile.sh.in
@@ -13,11 +13,10 @@
 if [ -n "@PACKAGE@" ] && [ -f "@PREFIX@/@PACKAGE@"/etc/bashrc ]
 then
     . "@PREFIX@/@PACKAGE@"/etc/bashrc -- || true
-    if [ -n "$PS1" ]
-    then
-        PS1="OpenFOAM\${FOAM_API+-$FOAM_API}:"'\w/\n\u\$ '
+    case "$-" in (*i*)  # Interactive shell
+        PS1="openfoam$(foamEtcFile -show-api 2>/dev/null):"'\w/\n\u\$ '
         alias sandbox='cd ${WM_PROJECT_DIR:?}/sandbox'
-    fi
+    esac  # Interactive shell
 fi
 
 

--- a/openfoam-run_leap.Dockerfile
+++ b/openfoam-run_leap.Dockerfile
@@ -1,0 +1,38 @@
+# ---------------------------------*-sh-*------------------------------------
+# Copyright (C) 2022 OpenCFD Ltd.
+# SPDX-License-Identifier: (GPL-3.0+)
+#
+# Create openfoam '-run' image for openSUSE using science repo.
+#
+# Example
+#     docker build -f openfoam-run_leap.Dockerfile .
+#     docker build --build-arg OS_VER=15.3 --build-arg FOAM_VERSION=2112 ...
+#
+# ---------------------------------------------------------------------------
+ARG OS_VER=15.3
+
+FROM opensuse/leap:${OS_VER} AS distro
+
+FROM distro AS runtime
+ARG FOAM_VERSION=2112
+ARG PACKAGE=openfoam${FOAM_VERSION}
+
+RUN zypper -n install -y \
+    nano wget rsync sudo nss_wrapper \
+ && zypper  -n addrepo -f --no-gpgcheck \
+    'https://download.opensuse.org/repositories/science/openSUSE_Leap_$releasever/' science \
+ && zypper install -y ${PACKAGE} \
+ && zypper -n clean
+
+# ---------------
+# User management
+# - nss-wrapper
+# - openfoam sandbox directory
+
+FROM runtime AS user
+COPY openfoam-files.rc/ /openfoam/
+RUN  /bin/sh /openfoam/assets/post-install.sh -fix-perms
+
+ENTRYPOINT [ "/openfoam/run" ]
+
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
OpenFOAM v2112 support using OpenSUSE-based images, as recommended in https://develop.openfoam.com/Development/openfoam/-/wikis/precompiled/docker#frequently-asked-questions. The new v2112 images are built using GitHub Actions.